### PR TITLE
Upgrade to node 20

### DIFF
--- a/.buildkite/scripts/deploy.sh
+++ b/.buildkite/scripts/deploy.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 TERRAFORM_ROLE="arn:aws:iam::760097843905:role/platform-ci"
+export AWS_PAGER=""
 
 # Do this here rather than in Dockerfile so we don't install it on every build/test
 apt install -y awscli zip
@@ -27,11 +28,9 @@ aws lambda update-function-code \
   --function-name $FUNCTION_NAME \
   --s3-bucket $S3_BUCKET \
   --s3-key $S3_KEY \
-  --s3-object-version $VERSION_ID \
-  --no-paginate
+  --s3-object-version $VERSION_ID
 
 aws lambda wait function-updated \
-  --function-name $FUNCTION_NAME \
-  --no-paginate
+  --function-name $FUNCTION_NAME 
 
 echo "Deployed function successfully!"

--- a/.buildkite/scripts/deploy.sh
+++ b/.buildkite/scripts/deploy.sh
@@ -16,6 +16,7 @@ cd $ROOT
 
 yarn package
 aws s3 cp $ROOT/package.zip "s3://${S3_BUCKET}/${S3_KEY}"
+
 VERSION_ID=$(aws s3api list-object-versions \
   --bucket $S3_BUCKET \
   --prefix $S3_KEY \
@@ -26,7 +27,11 @@ aws lambda update-function-code \
   --function-name $FUNCTION_NAME \
   --s3-bucket $S3_BUCKET \
   --s3-key $S3_KEY \
-  --s3-object-version $VERSION_ID
+  --s3-object-version $VERSION_ID \
+  --no-paginate
 
-aws lambda wait function-updated --function-name $FUNCTION_NAME
+aws lambda wait function-updated \
+  --function-name $FUNCTION_NAME \
+  --no-paginate
+
 echo "Deployed function successfully!"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
     && echo "${TERRAFORM_SHA256} /tmp/terraform.zip" | sha256sum -c - \
     && unzip /tmp/terraform.zip -d /usr/local/bin
 
-RUN apt update && apt install -y git
+RUN apt update && apt install -y git less
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM public.ecr.aws/docker/library/node:18
+FROM public.ecr.aws/docker/library/node:20
 
 # Install Terraform (for formatting)
-ARG TERRAFORM_VERSION=1.3.6
-RUN wget -O /tmp/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-  unzip -q -o /tmp/terraform.zip -d /usr/local/bin
+ARG TERRAFORM_VERSION=1.9.8
+ARG TERRAFORM_SHA256=186e0145f5e5f2eb97cbd785bc78f21bae4ef15119349f6ad4fa535b83b10df8
+RUN curl -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/terraform.zip \
+    && echo "${TERRAFORM_SHA256} /tmp/terraform.zip" | sha256sum -c - \
+    && unzip /tmp/terraform.zip -d /usr/local/bin
 
 RUN apt update && apt install -y git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
     && echo "${TERRAFORM_SHA256} /tmp/terraform.zip" | sha256sum -c - \
     && unzip /tmp/terraform.zip -d /usr/local/bin
 
-RUN apt update && apt install -y git less
+RUN apt update && apt install -y git
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   version = "2.2.0"
   hashes = [
     "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
     "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
     "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "4.48.0"
   hashes = [
     "h1:t/R3B4mibkp2zLer4MfhFbwHAVLAq71mJz4nwdUydBE=",
+    "h1:t4+ZVZIg8DbyFTMy4sZcvb7FULMG3mpg9Woh/2IaQ+o=",
     "zh:08f5e3c5256a4fbd5c988863d10e5279172b2470fec6d4fb13c372663e7f7cac",
     "zh:2a04376b7fa84681bd2938973c7d0822c8c0f0656a4e7661a2f50ac4d852d4a3",
     "zh:30d6cdf321aaba874934cbde505333d89d172d8d5ffcf40b6e66626c57bc6ab2",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,7 +11,7 @@ module "log_forwarder" {
 
   timeout                 = 15 * 60 // 15 minutes
   memory_size             = 512
-  runtime                 = "nodejs18.x"
+  runtime                 = "nodejs20.x"
   forward_logs_to_elastic = false // Prevent loops
 
   vpc_config = {


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5916

This change upgrades th lamdba to use Node 20.

## How to test

- [x] Apply the terraform, does the lambda still process requests?
- [x] Test a node 20 built zip in production, does it process requests?

## How can we measure success?

Less old node, more new node. Node!

## Have we considered potential risks?

If this breaks, it'll stop some subset of dev logs getting to the log server, not very impactful.
