### PR TITLE
Add any parseable json properties to the LogDocument

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -8,6 +8,14 @@ export const logEventToLogDocument =
   (event: CloudwatchLogEvent): LogDocument => ({
     id: event.id,
     "@timestamp": event.timestamp,
+    traceId: (() => {
+      const match = event.message.match(/"trace_id":\s*"([^"]+)"/);
+      return match ? match[1] : undefined;
+    })(),
+    logger: (() => {
+      const match = event.message.match(/"logger":\s*"([^"]+)"/);
+      return match ? match[1] : undefined;
+    })(),
     log: event.message,
     service,
   });

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -5,20 +5,28 @@ import { CloudwatchLogEvent, LogDocument } from "./types";
 
 export const logEventToLogDocument =
   (service: string) =>
-  (event: CloudwatchLogEvent): LogDocument => ({
-    id: event.id,
-    "@timestamp": event.timestamp,
-    traceId: (() => {
-      const match = event.message.match(/"trace_id":\s*"([^"]+)"/);
-      return match ? match[1] : undefined;
-    })(),
-    logger: (() => {
-      const match = event.message.match(/"logger":\s*"([^"]+)"/);
-      return match ? match[1] : undefined;
-    })(),
-    log: event.message,
-    service,
-  });
+  (event: CloudwatchLogEvent): LogDocument => {
+    // Extract JSON part from Lambda log format: [LEVEL]\t[TIMESTAMP]\t[REQUEST_ID]\t[JSON_MESSAGE]
+    const jsonMatch = event.message.match(/^\[.*?\]\t.*?\t.*?\t(.*?)(?:\n)?$/);
+
+    let parsedJson = {};
+    if (jsonMatch) {
+      try {
+        parsedJson = JSON.parse(jsonMatch[1]);
+      } catch (error) {
+        console.warn("Failed to parse JSON from log message:", error);
+      }
+    }
+
+    // If no jsonMatch or JSON parsing fails, continue with empty object
+    return {
+      id: event.id,
+      "@timestamp": event.timestamp,
+      log: event.message,
+      service,
+      ...parsedJson,
+    };
+  };
 
 const gunzip = promisify(zlib.gunzip);
 export const decodeBase64Gzipped = async <T>(blob: string): Promise<T> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,6 @@ export type CloudwatchLogEvent = {
 export type LogDocument = {
   id: string;
   "@timestamp": number;
-  traceId?: string;
-  logger?: string;
   log: string;
   service: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export type CloudwatchLogEvent = {
 export type LogDocument = {
   id: string;
   "@timestamp": number;
+  traceId?: string;
+  logger?: string;
   log: string;
   service: string;
 };

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -6,7 +6,6 @@ describe("transform", () => {
     const message = `[INFO]\t2025-11-11T10:05:05.362Z\t0f48ac76-2de9-456a-ad88-572036f60957\t{"s3_file_uri": "s3://wellcomecollection-catalogue-graph/graph_bulk_loader/2025-10-02/windows/20251111T0945-20251111T1000/catalogue_works__nodes.csv", "transformer_type": "catalogue_works", "entity_type": "nodes", "event": "Starting bulk load", "level": "info", "logger": "bulk_loader", "timestamp": "2025-11-11T10:05:05.361985Z", "pipeline_step": "graph_bulk_loader", "trace_id": "logging test", "started_at": "2025-11-11T10:05:05.361219+00:00"}\n`;
     const event = testLogEvent(message);
     const document = logEventToLogDocument("test-service")(event);
-    console.log(document);
 
     expect(document).toStrictEqual({
       id: event.id,

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -6,13 +6,25 @@ describe("transform", () => {
     const message = `[INFO]\t2025-11-11T10:05:05.362Z\t0f48ac76-2de9-456a-ad88-572036f60957\t{"s3_file_uri": "s3://wellcomecollection-catalogue-graph/graph_bulk_loader/2025-10-02/windows/20251111T0945-20251111T1000/catalogue_works__nodes.csv", "transformer_type": "catalogue_works", "entity_type": "nodes", "event": "Starting bulk load", "level": "info", "logger": "bulk_loader", "timestamp": "2025-11-11T10:05:05.361985Z", "pipeline_step": "graph_bulk_loader", "trace_id": "logging test", "started_at": "2025-11-11T10:05:05.361219+00:00"}\n`;
     const event = testLogEvent(message);
     const document = logEventToLogDocument("test-service")(event);
+    console.log(document);
 
-    expect(document.log).toBe(message);
-    expect(document.service).toBe("test-service");
-    expect(document.traceId).toBe("logging test");
-    expect(document.logger).toBe("bulk_loader");
-    expect(document["@timestamp"]).toBe(event.timestamp);
-    expect(document.id).toBe(event.id);
+    expect(document).toStrictEqual({
+      id: event.id,
+      "@timestamp": event.timestamp,
+      log: '[INFO]\t2025-11-11T10:05:05.362Z\t0f48ac76-2de9-456a-ad88-572036f60957\t{"s3_file_uri": "s3://wellcomecollection-catalogue-graph/graph_bulk_loader/2025-10-02/windows/20251111T0945-20251111T1000/catalogue_works__nodes.csv", "transformer_type": "catalogue_works", "entity_type": "nodes", "event": "Starting bulk load", "level": "info", "logger": "bulk_loader", "timestamp": "2025-11-11T10:05:05.361985Z", "pipeline_step": "graph_bulk_loader", "trace_id": "logging test", "started_at": "2025-11-11T10:05:05.361219+00:00"}\n',
+      service: "test-service",
+      s3_file_uri:
+        "s3://wellcomecollection-catalogue-graph/graph_bulk_loader/2025-10-02/windows/20251111T0945-20251111T1000/catalogue_works__nodes.csv",
+      transformer_type: "catalogue_works",
+      entity_type: "nodes",
+      event: "Starting bulk load",
+      level: "info",
+      logger: "bulk_loader",
+      timestamp: "2025-11-11T10:05:05.361985Z",
+      pipeline_step: "graph_bulk_loader",
+      trace_id: "logging test",
+      started_at: "2025-11-11T10:05:05.361219+00:00",
+    });
   });
 
   it("correctly decodes data that is compressed and base64-encoded", async () => {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -3,11 +3,14 @@ import { testLogEvent } from "./test-data";
 
 describe("transform", () => {
   it("transforms log events to log documents", () => {
-    const event = testLogEvent("Test message");
+    const message = `[INFO]\t2025-11-11T10:05:05.362Z\t0f48ac76-2de9-456a-ad88-572036f60957\t{"s3_file_uri": "s3://wellcomecollection-catalogue-graph/graph_bulk_loader/2025-10-02/windows/20251111T0945-20251111T1000/catalogue_works__nodes.csv", "transformer_type": "catalogue_works", "entity_type": "nodes", "event": "Starting bulk load", "level": "info", "logger": "bulk_loader", "timestamp": "2025-11-11T10:05:05.361985Z", "pipeline_step": "graph_bulk_loader", "trace_id": "logging test", "started_at": "2025-11-11T10:05:05.361219+00:00"}\n`;
+    const event = testLogEvent(message);
     const document = logEventToLogDocument("test-service")(event);
 
-    expect(document.log).toBe("Test message");
+    expect(document.log).toBe(message);
     expect(document.service).toBe("test-service");
+    expect(document.traceId).toBe("logging test");
+    expect(document.logger).toBe("bulk_loader");
     expect(document["@timestamp"]).toBe(event.timestamp);
     expect(document.id).toBe(event.id);
   });


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6135

This updates `logEventToLogDocument` to parse the json logged by the [logger module](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/catalogue_graph/src/utils/logger.py)

This is used to forward lambda logs exclusively so we can trust that the logs will come in the 
`[LEVEL]\t[TIMESTAMP]\t[REQUEST_ID]\t[JSON_MESSAGE]` 
format
If we can't find a match in the lambda log, or if the match can't be parsed, we still forward the original untouched `event.message` 

## How to test

Go to https://logging.wellcomecollection.org/login?next=%2F and search for `traceId: "logging test"` to filter the logs

## How can we measure success?

Easier to search and filter to find relevant logs

## Have we considered potential risks?

Potential loss of logs would be easily identified and remediated.
We still forward the original, unparsed log string 

